### PR TITLE
refactoring (mvn dependencies and toString())

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
     <logback-encoder.version>6.6</logback-encoder.version>
     <mockito-kotlin.version>4.0.0</mockito-kotlin.version>
     <token-support.version>1.3.9</token-support.version>
+    <springframework-cloud.version>3.0.4</springframework-cloud.version>
+    <squareup-okhttp3.version>4.9.2</squareup-okhttp3.version>
 
     <!-- build -->
     <build-helper-maven.version>3.2.0</build-helper-maven.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-    <springframework-cloud.version>3.0.3</springframework-cloud.version>
   </properties>
 
   <dependencyManagement>
@@ -169,6 +169,7 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-contract-stub-runner</artifactId>
       <version>${springframework-cloud.version}</version>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>
@@ -179,19 +180,19 @@
     <dependency>
       <groupId>no.nav.security</groupId>
       <artifactId>token-validation-spring-test</artifactId>
-      <version>1.3.9</version>
+      <version>${token-support.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>4.9.2</version>
+      <version>${squareup-okhttp3.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.9.2</version>
+      <version>${squareup-okhttp3.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/kotlin/no/nav/bidrag/arbeidsflyt/consumer/OppgaveConsumer.kt
+++ b/src/main/kotlin/no/nav/bidrag/arbeidsflyt/consumer/OppgaveConsumer.kt
@@ -43,20 +43,10 @@ class DefaultOppgaveConsumer(private val restTemplate: HttpHeaderRestTemplate) :
 
     private fun initStringOf(oppgaveSokResponse: OppgaveSokResponse?): String {
         if (oppgaveSokResponse != null) {
-            return "OppgaveSokResponse(antallTreff=${oppgaveSokResponse.antallTreffTotalt},oppgaver=[${initStringOf(oppgaveSokResponse.oppgaver)}]"
+            return "OppgaveSokResponse(antallTreff=${oppgaveSokResponse.antallTreffTotalt},oppgaver=[${oppgaveSokResponse.oppgaver}]"
         }
 
         return "no body, antall treff = 0"
-    }
-
-    private fun initStringOf(oppgaver: List<OppgaveData>): String {
-        val oppgaveBuilder = StringBuilder("")
-        oppgaver.forEach {
-            oppgaveBuilder.append(
-                "(id=${it.id},journalpostId=${it.journalpostId},tema=${it.tema},aktoerId=${it.aktoerId},oppgavetype=${it.oppgavetype})\n")
-        }
-
-        return oppgaveBuilder.toString()
     }
 
     override fun endreOppgave(patchOppgaveRequest: PatchOppgaveRequest) {

--- a/src/main/kotlin/no/nav/bidrag/arbeidsflyt/dto/oppgave.kt
+++ b/src/main/kotlin/no/nav/bidrag/arbeidsflyt/dto/oppgave.kt
@@ -77,6 +77,8 @@ data class OppgaveData(
         tema = tema,
         tildeltEnhetsnr = tildeltEnhetsnr
     )
+
+    override fun toString() = "{id=$id,journalpostId=$journalpostId,tema=$tema,aktoerId=$aktoerId,oppgavetype=$oppgavetype...}"
 }
 
 @Suppress("unused") // used by jackson...


### PR DESCRIPTION
- OppgaveData has customized toString()
- removed customized logging of OppgaveData from OppgaveConsumer
- bump springframework-cloud and only use it in test scope
- use versions of token-support and squareup-okhttp3 as properties